### PR TITLE
Fix for variable captured by anonymous function.

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -265,7 +265,7 @@ func (sc *SchedulerCore) ResourceOffers(driver sched.SchedulerDriver, offers []*
 		// TODO: Fix and make actually queues around driver interactions
 		// This is a massive hack
 		// -Sargun Dhillon 2015-10-01
-		go func() {
+		go func(offer *mesos.Offer) {
 			log.Infof("Launching Tasks: %v for offer %v", tasks, *offer.Id.Value)
 			status, err := driver.LaunchTasks([]*mesos.OfferID{offer.Id}, tasks, &mesos.Filters{RefuseSeconds: proto.Float64(OFFER_INTERVAL)})
 
@@ -275,7 +275,7 @@ func (sc *SchedulerCore) ResourceOffers(driver sched.SchedulerDriver, offers []*
 			if err != nil {
 				log.Panic("Failed to launch tasks: ", err)
 			}
-		}()
+		}(offer)
 	}
 }
 func (sc *SchedulerCore) StatusUpdate(driver sched.SchedulerDriver, status *mesos.TaskStatus) {


### PR DESCRIPTION
`offer` was captured by the closure so every time it was called it used
the value from the time it was initialized.  This resulted in the
framework only attempting to place nodes on the first host that made an
offer, as well as potentially other yet undiscovered issues.
