### PR TITLE
mustachify config templates

### DIFF
--- a/artifacts/data/advanced.config
+++ b/artifacts/data/advanced.config
@@ -1,7 +1,7 @@
 [
     {kernel,
         [
-            {cepmd_port, {{.CEPMDPort}}}
+            {cepmd_port, {{cepmdport}} }
         ]
     },
     {os_mon,

--- a/artifacts/data/riak.conf
+++ b/artifacts/data/riak.conf
@@ -103,7 +103,7 @@ log.crash.rotation.keep = 5
 ##
 ## Acceptable values:
 ##   - text
-nodename = {{.FullyQualifiedNodeName}}
+nodename = {{fullyqualifiednodename}}
 
 ## Cookie for distributed node communication.  All nodes in the
 ## same cluster should use the same cookie or they will not be able to
@@ -282,7 +282,7 @@ platform_log_dir = ./log
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-listener.http.internal = 0.0.0.0:{{.HTTPPort}}
+listener.http.internal = 0.0.0.0:{{httpport}}
 
 ## listener.protobuf.<name> is an IP address and TCP port that the Riak
 ## Protocol Buffers interface will bind.
@@ -291,7 +291,7 @@ listener.http.internal = 0.0.0.0:{{.HTTPPort}}
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-listener.protobuf.internal = 0.0.0.0:{{.PBPort}}
+listener.protobuf.internal = 0.0.0.0:{{pbport}}
 
 ## The maximum length to which the queue of pending connections
 ## may grow. If set, it must be an integer > 0. If you anticipate a
@@ -498,10 +498,10 @@ search.solr.jmx_port = 8985
 ##   - text
 search.solr.jvm_options = -d64 -Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops
 
-handoff.port = {{.HandoffPort}}
+handoff.port = {{handoffport}}
 javascript.reduce_pool_size = 0
 javascript.map_pool_size = 0
 javascript.hook_pool_size = 0
 
-erlang.distribution.port_range.minimum = {{.DisterlPort}}
-erlang.distribution.port_range.maximum = {{.DisterlPort}}
+erlang.distribution.port_range.minimum = {{disterlport}}
+erlang.distribution.port_range.maximum = {{disterlport}}


### PR DESCRIPTION
mustache template vars must start lowercase, no leading dot

mustache has a rendering bug where if a {{var}} is followed by a } without a space, it gets eaten
